### PR TITLE
Add marketing-focused landing with quick builder and showcase

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,30 +1,29 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Store, BookOpen } from "lucide-react";
+import { Store } from "lucide-react";
+import QuickBuilder from "@/components/quick-builder";
+import Showcase from "@/components/showcase";
 
 export default function HomePage() {
   return (
-    <main className="max-w-3xl mx-auto p-6 text-center space-y-4">
-      <Store className="w-12 h-12 mx-auto" />
-      <h1 className="text-3xl font-bold">ASCE Store</h1>
-      <p className="text-sm text-muted-foreground">
-        Autonomous Smart Craft Ecosystem – modular platforms for land, sea and air.
-      </p>
-      <p className="text-sm text-muted-foreground">
-        Explore our philosophy and build your own craft with the configurator.
-      </p>
-      <div className="flex justify-center gap-3 pt-2">
-        <Button asChild>
-          <Link href="/catalog">Browse Catalogue</Link>
-        </Button>
-        <Button variant="secondary" asChild>
-          <Link href="/store">Start Configurator</Link>
-        </Button>
-      </div>
-      <div className="pt-6 text-xs text-muted-foreground flex items-center justify-center gap-1">
-        <BookOpen className="w-4 h-4" />
-        <span>Learn more about our mission on the About page.</span>
-      </div>
+    <main className="max-w-5xl mx-auto p-6 space-y-12">
+      <section className="text-center space-y-4">
+        <Store className="w-12 h-12 mx-auto" />
+        <h1 className="text-3xl font-bold">Build the robotic platform you need</h1>
+        <p className="text-sm text-muted-foreground max-w-2xl mx-auto">
+          ASCE Platforms is a modular toolkit to assemble air, ground, or stationary robots tailored to your use-case. Use the configurator to explore options and place a demo pre-order.
+        </p>
+        <div className="flex justify-center gap-3 pt-2">
+          <Button asChild>
+            <Link href="/store">Start configuring</Link>
+          </Button>
+          <Button variant="secondary" asChild>
+            <Link href="#showcase">View showcase</Link>
+          </Button>
+        </div>
+      </section>
+      <QuickBuilder />
+      <Showcase />
     </main>
   );
 }

--- a/components/quick-builder.tsx
+++ b/components/quick-builder.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import ModelViewer from '@/components/ui/model-viewer';
+import { products, Product } from '@/lib/inventory';
+
+const BASE_IDS = ['platform-microtomba', 'circuit-microtomba-evo-esp32', 'battery-1600-2s'];
+const SENSOR_OPTIONS = [
+  { id: 'sensor-light', name: 'Light sensor' },
+  { id: 'sensor-color', name: 'Color sensor' },
+  { id: 'sensor-texo-line', name: 'Texo line sensor array' },
+];
+const COLORS = ['red', 'blue', 'green'];
+
+function hexFromIds(ids: string[]): string {
+  return ids
+    .join(',')
+    .split('')
+    .map((c) => c.charCodeAt(0).toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export default function QuickBuilder() {
+  const [sensors, setSensors] = useState<string[]>([]);
+  const [color, setColor] = useState<string>(COLORS[0]);
+
+  const ids = useMemo(() => [...BASE_IDS, ...sensors], [sensors]);
+
+  const bom = useMemo(() => {
+    const items = ids
+      .map((id) => products.find((p) => p.sku === id))
+      .filter(Boolean) as Product[];
+    const total = items.reduce((sum, item) => sum + item.price, 0);
+    return { items, total };
+  }, [ids]);
+
+  const hex = useMemo(() => hexFromIds(ids), [ids]);
+
+  const toggleSensor = (id: string) => {
+    setSensors((prev) =>
+      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]
+    );
+  };
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-xl font-semibold">Configurator — Design your platform</h2>
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Build your platform</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <div className="font-medium mb-2">Sensors</div>
+              {SENSOR_OPTIONS.map((s) => (
+                <label key={s.id} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={sensors.includes(s.id)}
+                    onChange={() => toggleSensor(s.id)}
+                  />
+                  {s.name}
+                </label>
+              ))}
+            </div>
+            <div>
+              <div className="font-medium mb-2">Color</div>
+              <select
+                className="border rounded-md px-2 py-1 text-sm"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+              >
+                {COLORS.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Estimate &amp; BOM</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <ul className="text-sm space-y-1">
+              {bom.items.map((item) => (
+                <li key={item.sku} className="flex justify-between">
+                  <span>{item.name}</span>
+                  <span>${item.price.toFixed(2)}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="flex justify-between border-t pt-2 font-semibold">
+              <span>Total</span>
+              <span>${bom.total.toFixed(2)}</span>
+            </div>
+            <Button className="w-full mt-4" variant="outline">
+              Pre-order (demo)
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+      <div className="space-y-2">
+        <ModelViewer label={`${color} µTomba`} />
+        <pre className="bg-gray-100 p-2 rounded text-xs overflow-x-auto">{hex}</pre>
+      </div>
+    </section>
+  );
+}
+

--- a/components/showcase.tsx
+++ b/components/showcase.tsx
@@ -1,0 +1,27 @@
+import ImgPh from '@/components/ui/img-ph';
+import { Card, CardContent } from '@/components/ui/card';
+
+const SHOWCASES = [
+  { id: 'drongaz', title: 'Drongaz — Research Quadcopter', type: 'Aerial' },
+  { id: 'microtomba', title: 'µTomba — 2WD Line Follower', type: 'Ground' },
+  { id: 'afus', title: 'AFUS — Desktop Robotic Arm', type: 'Stationary' },
+];
+
+export default function Showcase() {
+  return (
+    <section id="showcase" className="space-y-4">
+      <h2 className="text-xl font-semibold">Showcase — Recent builds</h2>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {SHOWCASES.map((s) => (
+          <Card key={s.id}>
+            <CardContent className="p-4 space-y-2">
+              <ImgPh label={s.type} />
+              <div className="font-medium text-sm">{s.title}</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- revamp home page with marketing hero, quick builder, and showcase links
- add quick builder for µTomba kits with sensor/color options, real-time BOM and hex
- include showcase section highlighting recent builds

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b05784eda4832a92d4c78e9ccd72b7